### PR TITLE
also show symlink'ed files

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,7 +106,8 @@ async function listEntries() {
         '-type', 'd',
         '-or',
         '-not', '-path', '*/.*',
-        '-type', 'f', '-iname', '*.gpg',
+        '(', '-type', 'f', '-or', '-type', 'l', ')',
+        '-iname', '*.gpg',
       ];
 
       if (process.platform === 'win32') {


### PR DESCRIPTION
I have some symlinks around in my `.password-store` which link from URLs (i.e. contextual entries) to actual entries that maybe have more memorable names.

Yet `listEntries` doesn't pick them up as it applies `-type f` filter to find command. This change simply picks up `-type l` as well, so passB extension happily lists the entry and `pass show` just understands them well